### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete URL substring sanitization

### DIFF
--- a/src/extractCourseLinks.py
+++ b/src/extractCourseLinks.py
@@ -2,7 +2,7 @@ import requests
 import os
 import re
 from bs4 import BeautifulSoup
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse
 import config
 from utils import extract_field, generate_course_md
 from validateHtml import validate_html
@@ -32,10 +32,12 @@ def download_image(img_url, filename):
     if os.path.exists(filename):
         return
     referer = None
+    parsed_url = urlparse(img_url)
+    host = (parsed_url.hostname or "").lower()
 
-    if "imgur.com" in img_url:
+    if host == "imgur.com" or host.endswith(".imgur.com"):
         referer = "https://imgur.com/"
-    elif "platzi.com" in img_url:
+    elif host == "platzi.com" or host.endswith(".platzi.com"):
         referer = "https://platzi.com/"
     headers = {
         "User-Agent": (


### PR DESCRIPTION
Potential fix for [https://github.com/OscarDogar/Platzi-Download/security/code-scanning/1](https://github.com/OscarDogar/Platzi-Download/security/code-scanning/1)

General fix: parse the URL and inspect its hostname instead of scanning the raw URL string. Then match allowed hosts exactly (or as controlled subdomains) using hostname-aware checks.

Best fix for this snippet: in `src/extractCourseLinks.py`, import `urlparse` and replace the substring checks in `download_image` with parsed-host checks. Use `hostname == "imgur.com" or hostname.endswith(".imgur.com")` (and same for `platzi.com`) so only the actual host or its subdomains match, not arbitrary URL substrings.

Needed changes:
- Update imports in `src/extractCourseLinks.py`: add `urlparse` to existing `urllib.parse` import.
- In `download_image`, parse `img_url` once, normalize hostname to lowercase, and use hostname-based checks to set `referer`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
