### PR TITLE
feat: support for complete learning paths (/ruta/...)

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -67,6 +67,13 @@ BASE_FOLDER = "Videos"
 DYNAMIC_NAME = None
 FULL_PATH = None
 
+ROUTE_NAME = None
+
+
+def set_route_name(name):
+    global ROUTE_NAME
+    ROUTE_NAME = name
+
 
 def set_dynamic_name(name):
     """
@@ -89,7 +96,10 @@ def set_dynamic_name(name):
     """
     global DYNAMIC_NAME, FULL_PATH, FULL_PATH_HTML, FULL_PATH_LINKS, FULL_PATH_VIDEOS, FULL_PATH_RESOURCES
     DYNAMIC_NAME = name
-    FULL_PATH = f"{BASE_FOLDER}/{DYNAMIC_NAME}"
+    if ROUTE_NAME:
+        FULL_PATH = f"{BASE_FOLDER}/{ROUTE_NAME}/{DYNAMIC_NAME}"
+    else:
+        FULL_PATH = f"{BASE_FOLDER}/{DYNAMIC_NAME}"
     FULL_PATH_LINKS = FULL_PATH + "/VideosLinks"
     FULL_PATH_HTML = FULL_PATH + "/responses"
     FULL_PATH_VIDEOS = FULL_PATH + "/videos.json"

--- a/src/extractRouteLinks.py
+++ b/src/extractRouteLinks.py
@@ -1,0 +1,70 @@
+import os
+import re
+import requests
+from urllib.parse import urljoin
+from bs4 import BeautifulSoup
+
+import config
+from extractCourseLinks import cleanName
+from validateHtml import verify_cookie
+
+COURSE_HREF_RE = re.compile(r'href="(/cursos/[a-zA-Z0-9\-]+/?)"')
+
+
+def is_route_url(url: str) -> bool:
+    return "/ruta/" in url
+
+
+def getRouteCourseLinks(url: str):
+    base = "https://platzi.com"
+    try:
+        session = requests.Session()
+        for key, value in config.COOKIES.items():
+            session.cookies.set(key, value, domain=".platzi.com")
+        response = session.get(
+            url,
+            headers=config.headers,
+            cookies=config.COOKIES,
+            timeout=20,
+        )
+        response.raise_for_status()
+        html = response.text
+        soup = BeautifulSoup(html, "html.parser")
+        verify_cookie(soup)
+    except requests.RequestException:
+        print("An exception occurred while fetching the route page.")
+        os._exit(1)
+    except Exception as e:
+        print(str(e))
+        os._exit(1)
+
+    title_tag = soup.select_one("h1")
+    route_name = cleanName(title_tag.get_text(strip=True)) if title_tag else "Ruta"
+
+    seen = set()
+    course_urls = []
+    for match in COURSE_HREF_RE.finditer(html):
+        href = match.group(1)
+        full_url = urljoin(base, href)
+        if full_url not in seen:
+            seen.add(full_url)
+            course_urls.append(full_url)
+
+    if not course_urls:
+        for a in soup.find_all("a", href=True):
+            href = a["href"]
+            if "/cursos/" in href:
+                full_url = urljoin(base, href)
+                if full_url not in seen:
+                    seen.add(full_url)
+                    course_urls.append(full_url)
+
+    if not course_urls:
+        print(
+            "No courses were found on the route page. "
+            "Platzi may have changed its page structure, or the cookie/session "
+            "does not have access to this route."
+        )
+
+    print(f"Route detected: {route_name} ({len(course_urls)} courses found)")
+    return route_name, course_urls

--- a/src/main.py
+++ b/src/main.py
@@ -29,6 +29,7 @@ Exit Behavior:
 """
 
 from extractCourseLinks import getLinks
+from extractRouteLinks import is_route_url, getRouteCourseLinks
 from openLinks import openLinks
 import config
 from getVideosLink import openVideoLinks
@@ -70,6 +71,17 @@ def process_course(url: str) -> None:
         print("You can run the script again to retry missing downloads.")
 
 
+def process_route(url: str) -> None:
+    print(f"\n🛤️  Processing route: {url}")
+    route_name, course_urls = getRouteCourseLinks(url)
+    config.set_route_name(route_name)
+    try:
+        for course_url in course_urls:
+            process_course(course_url)
+    finally:
+        config.set_route_name(None)
+
+
 def main() -> None:
     """
     Main entry point for the application.
@@ -78,7 +90,10 @@ def main() -> None:
         menu()
         config.validate_config()
         for url in config.COURSE_URL:
-            process_course(url)
+            if is_route_url(url):
+                process_route(url)
+            else:
+                process_course(url)
         print("\n🚀 All done!")
         print(
             clickable_link(


### PR DESCRIPTION
Soporte para descargar rutas completas, no solo cursos individuales. No se ha modificado nada del actual flujo. Simplemente `COURSE_URL` ahora soportará también URLs de ruta: `COURSE_URL=platzi.com/ruta/<slug>/`

## Cambios: 

- Nuevo `extractRouteLinks.py`: detecta si una URL es de tipo `/ruta/` y, si lo es, extrae sus `/cursos/<slug>/` subyacentes (regex sobre HTML crudo, con fallback a `<a href>` genérico, para ser resistente a cambios sobre clases).

- `main.py`: si la URL es una ruta, se expande en sus cursos; cada cual se procesa con el pipeline existente (`process_course`), sin trastocar lo ya construido.

- `config.py`: nuevo `ROUTE_NAME` + `set_route_name()` para anidar la salida como `Videos/<Nombre Ruta>/<Nombre Curso>/` en lugar de mezclarle con cursos sueltos.

