### PR TITLE
fix: parse COURSE_URL lists separated by newlines, not only commas

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -64,9 +64,13 @@ except KeyError:
     raise RuntimeError("COOKIE environment variable is not set")
 
 COURSE_URL = os.environ.get("COURSE_URL")
-# convert COURSE_URL to a list if it contains multiple URLs separated by commas
+# Split on commas and/or whitespace so a URL-per-line list in .env works
 if COURSE_URL:
-    COURSE_URL = [url.strip() for url in COURSE_URL.split(",")]
+    COURSE_URL = [
+        url.strip()
+        for url in COURSE_URL.replace(",", " ").split()
+        if url.strip()
+    ]
 else:
     raise RuntimeError("COURSE_URL environment variable is not set")
 


### PR DESCRIPTION
## Summary

`COURSE_URL` was split only on commas. A quoted, one-URL-per-line list in `.env` became a **single invalid URL** with embedded newlines, so the first request failed with `An exception occurred while fetching the page.`

This change splits on commas **and** any whitespace (spaces, newlines, tabs), then trims empty tokens. Comma-separated values keep working.

## Problem

With a readable `.env` like:

```env
COURSE_URL="
https://platzi.com/cursos/EXAMPLE_1/
https://platzi.com/cursos/EXAMPLE_2/
https://platzi.com/cursos/EXAMPLE_3/
"
```

the parser produced one string:

```
https://platzi.com/cursos/EXAMPLE_1/\nhttps://platzi.com/cursos/EXAMPLE_2/\n...
```

`main.py` then tried to fetch that as a single course. Logs showed every URL glued under one `Processing course:` line, then the fetch crashed.

## Solution

In `src/config.py`, replace commas with spaces and use `str.split()` (splits on any whitespace and drops empties):

- one URL per line (quoted multiline `COURSE_URL`)
- comma-separated on one line
- mixed commas and line breaks

Each URL is still passed through `.strip()`.

## Examples that now work

```env
# One URL per line
COURSE_URL="https://platzi.com/cursos/EXAMPLE_1/
https://platzi.com/cursos/EXAMPLE_2/"

# Commas (previous format)
COURSE_URL=https://platzi.com/cursos/EXAMPLE_1/,https://platzi.com/cursos/EXAMPLE_2/

# Mixed
COURSE_URL="https://platzi.com/cursos/EXAMPLE_1/,
https://platzi.com/ruta/EXAMPLE_2/"
```